### PR TITLE
Error "The value -1 is not of type (UNSIGNED-BYTE 64) when setting slot CL-ISAAC::RANDCNT of structure CL-ISAAC:ISAAC64-CTX".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog][], and this project adheres to [Semant
 
 ## [Unreleased]
 
+### Fixed
+
+- Error "The value -1 is not of type (UNSIGNED-BYTE 64) when setting slot CL-ISAAC::RANDCNT of structure CL-ISAAC:ISAAC64-CTX".
+
+  This error happened when you set optimization policy `SAFETY > 0` in SBCL.
+  
+  Closes issue https://github.com/thephoeron/cl-isaac/issues/12.
+
 ## [1.0.8] - 2023-06-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ If you find any bugs, please report them at: https://github.com/thephoeron/cl-is
 
 Make sure you have the latest Quicklisp distribution. Include CL-ISAAC as a dependency in your system definition, or evaluate `(ql:quickload "cl-isaac")` from the REPL.
 
-First, you need to create an isaac context.  If you have a 64-bit implementation of Lisp on an x86-64 platform, you can set `:is64 t` to take advantage of the ISAAC-64 algorithm. There are four functions that do this:
+First, you need to create an isaac context.
+
+**WARNING - Thread Safety**: If your application is multi-threaded and you are passing in a seed variable, you must add a lock to the seed variable. With Bordeaux Threads it can be done with `bt2:with-lock`
+
+If you have a 64-bit implementation of Lisp on an x86-64 platform, you can set `:is64 t` to take advantage of the ISAAC-64 algorithm. There are four functions that do this:
 
 **isaac:init-self-seed** &key (count 1) (is64 nil) => *`<isaac context>`*
 

--- a/isaac-32.lisp
+++ b/isaac-32.lisp
@@ -47,15 +47,15 @@
       (setf (aref (isaac-ctx-randrsl ctx) i) (isaac-ctx-b ctx)))))
 
 (defun rand32 (ctx)
-  (let ((c (isaac-ctx-randcnt ctx)))
-    ;(declare (optimize (speed 3) (safety 0)))
-    (decf (isaac-ctx-randcnt ctx))
-    (if (zerop c)
-      (progn
-        (generate-next-isaac-block ctx)
-        (setf (isaac-ctx-randcnt ctx) 255)
-        (aref (isaac-ctx-randrsl ctx) 255))
-      (aref (isaac-ctx-randrsl ctx) (isaac-ctx-randcnt ctx)))))
+  ;;(declare (optimize (speed 3) (safety 0)))
+  (cond
+    ((zerop (isaac-ctx-randcnt ctx))
+     (generate-next-isaac-block ctx)
+     (setf (isaac-ctx-randcnt ctx) 255)
+     (aref (isaac-ctx-randrsl ctx) 255))
+    (t
+     (aref (isaac-ctx-randrsl ctx)
+           (decf (isaac-ctx-randcnt ctx))))))
 
 (defun rand-bits (ctx n)
   (let ((v 0))

--- a/isaac-64.lisp
+++ b/isaac-64.lisp
@@ -62,10 +62,10 @@
 (defun rand-bits-64 (ctx n)
   (let ((v 0))
     (loop while (> n 0) do
-          (setq v (logior (ash v (min n 64))
-                          (logand (1- (ash 1 (min n 64)))
-                                  (rand64 ctx))))
-          (decf n (min n 64)))
+      (setq v (logior (ash v (min n 64))
+                      (logand (1- (ash 1 (min n 64)))
+                              (rand64 ctx))))
+      (decf n (min n 64)))
     v))
 
 (defmacro incf-wrap64 (a b)

--- a/isaac-64.lisp
+++ b/isaac-64.lisp
@@ -49,23 +49,23 @@
       (setf (aref (isaac64-ctx-randrsl ctx) i) (isaac64-ctx-b ctx)))))
 
 (defun rand64 (ctx)
-  (let ((c (isaac64-ctx-randcnt ctx)))
-    ;(declare (optimize (speed 3) (safety 0)))
-    (decf (isaac64-ctx-randcnt ctx))
-    (if (zerop c)
-      (progn
-        (generate-next-isaac64-block ctx)
-        (setf (isaac64-ctx-randcnt ctx) 255)
-        (aref (isaac64-ctx-randrsl ctx) 255))
-      (aref (isaac64-ctx-randrsl ctx) (isaac64-ctx-randcnt ctx)))))
+  ;;(declare (optimize (speed 3) (safety 0)))
+  (cond
+    ((zerop (isaac64-ctx-randcnt ctx))
+     (generate-next-isaac64-block ctx)
+     (setf (isaac64-ctx-randcnt ctx) 255)
+     (aref (isaac64-ctx-randrsl ctx) 255))
+    (t
+     (aref (isaac64-ctx-randrsl ctx)
+           (decf (isaac64-ctx-randcnt ctx))))))
 
 (defun rand-bits-64 (ctx n)
   (let ((v 0))
     (loop while (> n 0) do
-      (setq v (logior (ash v (min n 64))
-                      (logand (1- (ash 1 (min n 64)))
-                              (rand64 ctx))))
-      (decf n (min n 64)))
+          (setq v (logior (ash v (min n 64))
+                          (logand (1- (ash 1 (min n 64)))
+                                  (rand64 ctx))))
+          (decf n (min n 64)))
     v))
 
 (defmacro incf-wrap64 (a b)


### PR DESCRIPTION
This error happened when you set optimization policy `SAFETY > 0` in SBCL.

Closes issue https://github.com/thephoeron/cl-isaac/issues/12.